### PR TITLE
Feature/parse xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .idea/
+data/

--- a/rg-schema.xsd
+++ b/rg-schema.xsd
@@ -10,12 +10,12 @@
 
     <xs:simpleType name="roleType">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="Main PI">
+            <xs:enumeration value='"Main PI"'>
                 <xs:annotation>
                     <xs:documentation>Registered as main PI at AEA RCT Registry.</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
-            <xs:enumeration value="Other PI">
+            <xs:enumeration value='"Other PI"'>
                 <xs:annotation>
                     <xs:documentation>Other PIs listed at AEA RCT Registry.</xs:documentation>
                 </xs:annotation>

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,7 @@ setup(
     description='Repository with the tooling for capturing data from social science registry trials',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    install_requires=['pandas==2.0.3'],
+    install_requires=['pandas==2.0.3',
+                      'xmlschema==2.3.1'
+                      ],
 )

--- a/src/rgtools/cli.py
+++ b/src/rgtools/cli.py
@@ -1,11 +1,15 @@
 from argparse import ArgumentParser
 from .aea_rct_registry.AEAtrials import read_trials, get_trial_from_number, templatedct_from_trialdct, Template, trial_template
+from .xml_processing.generate_latex import XMLToLatex
 
 parser = ArgumentParser(prog='rgtools')
 subparsers = parser.add_subparsers(dest="command", required=True)
 
 get_trials_parser = subparsers.add_parser("get_trials", help="Get Trial Template from AEA RCT Registry")
 get_trials_parser.add_argument('-t', '--trial_id', help="Registration ID from the AEA RCT Registry")
+
+generate_latex_parser = subparsers.add_parser("generate_latex_parser", help="Generate Latex of the coding of AEA RCT Registry")
+generate_latex_parser.add_argument('-x', '--xml_path', help="Path to XML File")
 
 
 def get_trials(args):
@@ -18,7 +22,11 @@ def get_trials(args):
     print(t.safe_substitute(tdct))
 
 
+
 def main(args=None):
     args = parser.parse_args(args=args)
     if args.command=='get_trials':
         get_trials(args)
+
+    elif args.command=="generate_latex_parser":
+        XMLToLatex(args.xml_path).run()

--- a/src/rgtools/xml_processing/generate_latex.py
+++ b/src/rgtools/xml_processing/generate_latex.py
@@ -1,0 +1,108 @@
+from xmlschema import XMLSchema
+
+class XMLToLatex:
+	def __init__(self, file_path):
+		self.file_path = file_path
+		self.trial_schema = None
+		self.trial_object = None
+		self.latex_lines = []
+
+	def add_to_latex(self,line):
+		if isinstance(line,str):
+			self.latex_lines.append(line)
+		elif isinstance(line,list):
+			self.latex_lines += line
+
+	def escape_text(self,text):
+		text = text.replace("_","\_")
+		return text
+
+	def clean_title(self, title):
+		title = title.title()
+		title = title.replace("_"," ")
+		return title
+
+	def flatten_values(self,value):
+		if isinstance(value,list):
+			return ', '.join(value)
+		else:
+			return value
+
+	def itemize_dict(self, dict_to_itemezie, bullet_symbol="-"):
+		itemized_list = ["\\begin{itemize}"]
+		items = [(self.clean_title(key), self.escape_text(self.flatten_values(value)) ) for key, value in dict_to_itemezie.items() if key!="label"]
+		itemized_list += [f'\item[-] \\textbf{{{key}}}: {value}' for key, value in items]
+		itemized_list += ["\\end{itemize}"]
+		return itemized_list
+
+	def get_trial_schema(self,):
+		self.trial_schema = XMLSchema('rg-schema.xsd')
+
+	def get_trial_object(self):
+		self.trial_object = self.trial_schema.to_dict(self.file_path)
+
+	def initialize_latex(self):
+		self.add_to_latex("\documentclass{article}")
+		self.add_to_latex("\\title{AEA RCT Trial Registration}")
+		self.add_to_latex(f"\\author{{RCT Trial ID: {self.trial_object['registration_number']}}}")
+		self.add_to_latex("\\begin{document}")
+		self.add_to_latex("\\maketitle")
+
+
+
+	def close_latex(self):
+		self.add_to_latex("\end{document}")
+
+	def add_populations(self):
+		self.add_to_latex("\section{Populations}")
+		for population in self.trial_object['populations']['population']:
+			label = population['label']
+			self.add_to_latex(f'\subsection{{{self.escape_text(label)}}}')
+			self.add_to_latex(self.itemize_dict(population))
+
+	def add_outcomes(self):
+		self.add_to_latex("\section{Outcomes}")
+		for outcome in self.trial_object['main_outcomes']['main_outcome']:
+			label = outcome['label']
+			self.add_to_latex(f'\subsection{{{self.escape_text(label)}}}')
+			self.add_to_latex(self.itemize_dict(outcome))
+
+	def add_interventions(self):
+		self.add_to_latex("\section{Interventions}")
+		for intervention in self.trial_object['interventions']['intervention']:
+			label = intervention['label']
+			self.add_to_latex(f'\subsection{{{self.escape_text(label)}}}')
+			self.add_to_latex(self.itemize_dict(intervention))
+	def add_arms(self):
+		self.add_to_latex("\section{Arms}")
+		for arm in self.trial_object['arms']['arm']:
+			label = arm['label']
+			self.add_to_latex(f'\subsection{{{self.escape_text(label)}}}')
+			self.add_to_latex(self.itemize_dict(arm))
+
+	def write_latex(self):
+		output_filename = self.file_path.replace(".xml",".latex")
+		with open(output_filename, "w") as outfile:
+			outfile.write("\n".join(self.latex_lines))
+
+	def generate_latex(self):
+		self.initialize_latex()
+		self.add_populations()
+		self.add_outcomes()
+		self.add_interventions()
+		self.add_arms()
+		self.close_latex()
+
+	def run(self):
+		self.get_trial_schema()
+		self.get_trial_object()
+		self.generate_latex()
+		self.write_latex()
+
+# trial_487 = XMLToLatex('data/487_Viviane.xml')
+# trial_487.run()
+
+# trial_487.latex_lines
+# trial_487.trial_object['arms']['arm']
+# from pprint import pprint
+# pprint(trial_487.trial_object['arms']['arm'])

--- a/src/rgtools/xml_processing/generate_latex.py
+++ b/src/rgtools/xml_processing/generate_latex.py
@@ -98,11 +98,3 @@ class XMLToLatex:
 		self.get_trial_object()
 		self.generate_latex()
 		self.write_latex()
-
-# trial_487 = XMLToLatex('data/487_Viviane.xml')
-# trial_487.run()
-
-# trial_487.latex_lines
-# trial_487.trial_object['arms']['arm']
-# from pprint import pprint
-# pprint(trial_487.trial_object['arms']['arm'])


### PR DESCRIPTION
This commit adds the ability to generate a latex file from the XML coding of the trial registration. Can be run using the following command:

```bash
python -m rgtools generate_latex_parser --xml_path path_to_xml/XYZ.xml
``` 

This will create a latex file called `XYZ.latex` in the same location as the XML file.